### PR TITLE
type mismatch in examples fixed

### DIFF
--- a/examples/src/main/scala/za/co/absa/KafkaCase/Examples/KafkaCase.scala
+++ b/examples/src/main/scala/za/co/absa/KafkaCase/Examples/KafkaCase.scala
@@ -33,7 +33,7 @@ object KafkaCase {
       app_id_snow = "N/A",
       source_app = "ThisCode",
       environment = "DEV",
-      timestamp_event = "RIGHT_NOW",
+      timestamp_event = 12345,
       data_definition = "TestingThis",
       operation = EdlaChangeTopic.Operation.CREATE(),
       location = "ether",


### PR DESCRIPTION
timestamp is no longer string, so sample should not be string either