### PR TITLE
#21 README extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To run unit tests cross-scala versions on clean build, run:
 
 To run examples, run:
 `sbt "project examples" run`
+It might be worthwhile to change the main (examples module KafkaCase main class), to only run the part you are copy-pasting into your implementation so you can watch and debug that one
 
 ## Architecture
 
@@ -65,11 +66,12 @@ Sample usage of the library can be observed in Examples module
 
 Whole module showcases simple scenario how to use writer as well as reader. Each scenario is showcased in 3 different flavors.
 - ManualResourceHandling
-  - User is expected to manually dispose of resource after using it 
+  - User is expected to manually dispose of resource after using it
 - CustomResourceHandling
   - custom code encapsulating resource usage is used
 - UsingsResourceHandling
   - Usings paradigm is used, note, this requires scala version 3
+  - Samples are in scala3 specific folder due to compiler reasons for scala 2
 
 Simply executing example module as is, demonstrates usage in following order:
 - 0 part before the main method collects necessary requirements (message class, settings etc...) which user is expected to obtain from its application/config


### PR DESCRIPTION
there seems to be confusion about how examples are supposed to work, so the readme is extended

note: readme corresponds to version already after #17, where 3 different flavors of resource handling are show-cased and better separated

closes #21 